### PR TITLE
[TWEAK] Вернуть шедоукинов, кошкотварей и йоуи. Ну ок, энд?

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
@@ -21,7 +21,7 @@
 - type: species
   id: Felinid
   name: species-name-felinid
-  roundStart: false # Goobstation change
+  roundStart: true # Goobstation change
   prototype: MobFelinid
   sprites: MobHumanSprites
   markingLimits: MobFelinidMarkingLimits

--- a/Resources/Prototypes/_DV/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Species/chitinid.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Chitinid
   name: species-name-chitinid
-  roundStart: false # CorvaxGoob : Temporary hidden
+  roundStart: true # CorvaxGoob : Temporary hidden
   prototype: MobChitinid
   sprites: MobChitinidSprites
   defaultSkinTone: "#ffda93"

--- a/Resources/Prototypes/_DV/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Species/rodentia.yml
@@ -16,7 +16,7 @@
 - type: species
   id: Rodentia
   name: species-name-rodentia
-  roundStart: false # CorvaxGoob Temporary hidden
+  roundStart: true # CorvaxGoob Temporary hidden
   prototype: MobRodentia
   sprites: MobRodentiaSprites
   defaultSkinTone: "#747474"

--- a/Resources/Prototypes/_EinsteinEngines/Species/shadowkin.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Species/shadowkin.yml
@@ -7,7 +7,7 @@
 - type: species
   id: Shadowkin
   name: species-name-shadowkin
-  roundStart: false # CorvaxGoob Temporary hidden
+  roundStart: true # CorvaxGoob Temporary hidden
   prototype: MobShadowkin
   sprites: MobShadowkinSprites
   defaultSkinTone: "#FFFFFF"

--- a/Resources/Prototypes/_Goobstation/Species/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Species/yowie.yml
@@ -13,7 +13,7 @@
 - type: species
   id: Yowie
   name: species-name-yowie
-  roundStart: false # CorvaxGoob LRP bullshit
+  roundStart: true # CorvaxGoob LRP bullshit
   prototype: MobYowie
   sprites: MobYowieSprites
   markingLimits: MobYowieMarkingLimits


### PR DESCRIPTION
# Наныли.

- tweak: Изменено то, что кошкотвари(фелиниды), шедоукины, йоуи, хитиниды и родентии не были раундстартовыми расами по тем или иным причинам. 

(с балансом всё плохо только у йоуи, но меня просили их вернуть хз, как мейнтейнер скажет так и будет)

## Шедоукины, они же тенекины
<img width="422" height="387" alt="{AEAB76D4-405F-42E3-B134-5416D8D7C819}" src="https://github.com/user-attachments/assets/a7e45d94-705a-45a4-b094-6b7ba8ce39da" />

## Упаси господь
<img width="398" height="395" alt="{DBE0F5ED-B1CC-4641-9719-CC7FDC462732}" src="https://github.com/user-attachments/assets/5127c67f-4d94-4a9f-b0eb-dacf1a1666ac" />

## Родентия

<img width="472" height="415" alt="{1E66C366-1F9F-41B1-869E-63847C351A4A}" src="https://github.com/user-attachments/assets/bad9a8fd-332f-4712-a3fd-929d99883572" />

## Йоуи

<img width="392" height="416" alt="{642FAFFD-13C5-4C6B-9E97-7403B75D1699}" src="https://github.com/user-attachments/assets/e17fe6ff-1b43-40ff-a5b8-a9b9d2b1db96" />

<img width="980" height="722" alt="{F2155361-2439-486F-8AF8-148F308E4167}" src="https://github.com/user-attachments/assets/50d748f7-9a05-4afb-b273-9c26da1770e1" />

## Хитинид
<img width="425" height="411" alt="{6F487BC2-8B59-41C3-BF34-A7CDEBC3B29D}" src="https://github.com/user-attachments/assets/eea501bb-0017-4668-9d7f-67b8135d8f1a" />
