### PR TITLE
[code and gamemode addition] Deathmatch fix - Danone10012

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -149,6 +149,19 @@
 - type: entity
   parent: BaseUplinkRadio
   # Goobstation - Telecrystal rework
+  id: BaseUplinkOpsRadio100TC
+  suffix: 100 TC, Nukeops Deathmatch #(LoneOps suffix Removed)
+  components:
+  - type: Store
+    balance:
+      Telecrystal: 100
+  - type: Tag
+    tags:
+    - NukeOpsUplink
+
+- type: entity
+  parent: BaseUplinkRadio
+  # Goobstation - Telecrystal rework
   id: BaseUplinkRadio125TC
   suffix: 125 TC
   components:

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -240,8 +240,12 @@
     shoes: ClothingShoesBootsJack
     ears: ClothingHeadsetGrey
     gloves: ClothingHandsGlovesFingerless
-  inhand:
-    - WeaponMeleeToolboxRobust
+    belt: ClothingBeltStorageWaistbag
+    id: CentcomPDA
+    pocket1: BaseUplinkRadio100TC
+    pocket2: BaseUplinkOpsRadio100TC
+    outerClothing: ClothingOuterArmorBasic
+
 
 #Brigmedic
 


### PR DESCRIPTION
I added that :3 - Даноне один ноль ноль один два четырнадцать двоеточие сорок девять

<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Ko4ergaPunk <nikitako4erga3i5@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## Описание PR
Добавил аплинк опера на 100тк (так как другого выхода я не увидел)

Изменил equipment у Deathmatch loadout, а именно:
-убрал Робастный тулбокс

-добавил кпк центкома
-добавил аплинк предов в первом кармане на 100 тк
-добавил аплинк оперов во втором кармане на 100 тк
-добавил поясную сумку
-добавил бронежилет I типа

## Почему / Баланс
_Убрал робаст тулбокс, так как для меня эта вещь кажется слишком сильной 
решил сделать небольшой "магазин" используя аплинк, где можно было себе самому собрать билд и оружие
_Добавил кпк центкома чтобы был доступ ко всей станции и чтобы не возникало лишних проблем, кпк оснащён медтеком
-Добавил бронежилет чтобы была небольшая броня и можно было носить оружие за спиной
-Добавил поясную сумку, но не рюкзак в угоду баланса и развития путём лутания ТК у людей
-Также добавил визор который показывает роли и хп НО НЕ ЗАЩИЩАЕТ ОТ ВСПЫШЕК!! (я проверял)
сделано это чтобы сделать вспышки и флешки хоть как-то полезными

## Технические детали
две кпк нужны лишь потому, чтобы можно было купить снаряжение как и предателя (предательский нож), так и опера (Ящик с вооружением, броня)
Визор не защищает от вспышек
## Медиа

<img width="1583" height="908" alt="image" src="https://github.com/user-attachments/assets/6ef32833-0e72-462e-9a43-b8a22e98542e" />
тот самый аплинк оперов на 100 тк
![Uploading image.png…]()
как выглядит сам лоадаут

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [х] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [х] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
Нету :3
**Список изменений**
:cl:
- add: Добавлен броник I класса в лоадаут дезматча!
- add: Добавлен не защищающий от вспышек охран/мед визор в лоадаут дезматча!
- add: Добавлена малая поясная сумка в лоадаут дезматча!
- add: Добавлены два аплинка на 100 тк (оперский и предательский) в лоадаут дезматча!
- remove: Удален робаст тулобкс из Лоадаута Дезматча!
- tweak: Дополнительно добавил аплинк оперов на 100 тк на щитспавн!
-->
