### PR TITLE
[TWEAK] Цвет и выделение ERP статуса на персонаже

### DIFF
--- a/Content.Server/_FreakyStation/ERP/ERPSystem.cs
+++ b/Content.Server/_FreakyStation/ERP/ERPSystem.cs
@@ -37,7 +37,7 @@ namespace Content.Server.ERP
         {
             if (component.Erp)
             {
-                args.PushMarkup("[color=#ff00ff]ERP: ВКЛЮЧЕНО[/color]");
+                args.PushMarkup("[color=#ff85ff][bold]ERP статус — ВКЛЮЧЕНО.[/color][/bold]");
             }
         }
         private void OnPlayerSpawned(PlayerSpawnCompleteEvent ev)


### PR DESCRIPTION
Вообще, хотелось бы сделать проверку на ERP true, и чтобы ERP компонент при заходе добавлялся даже без черты ERP, но с выключенным ERP статусом сделать отображение, что ERP статус выключен. Но мне в падлу слишком это кодить, при том факте что я даже синтаксиса толком не знаю пока что

По поводу ПРа, мне глазам не очень приятно и мне кажется так выглядело бы лучше, хотя кншн субъективная херь.
Было:
<img width="294" height="197" alt="{4A4F781B-7845-4523-B1DC-A3EE95124179}" src="https://github.com/user-attachments/assets/4cdd078a-4ef5-4484-b287-d13d724f21b6" />

Стало:
<img width="420" height="256" alt="{529A7BAB-2B66-4C5E-BD93-E10344604930}" src="https://github.com/user-attachments/assets/71f84147-122a-43c7-bf03-7092f9556276" />

<img width="402" height="246" alt="{6C440A74-504C-4D1C-98E2-94B0D9E6918F}" src="https://github.com/user-attachments/assets/84abaf8d-45f3-4590-a5b2-a854f4ae33d7" />

