### PR TITLE
[TWEAK] 0 seconds cooldown adminhelp

### DIFF
--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -198,7 +198,7 @@ namespace Content.Server.Administration.Systems
         private const ushort MessageLengthCap = 3000;
 
         // Mini-Ahelp-Antispam-Start
-        private readonly TimeSpan _messageCooldown = TimeSpan.FromSeconds(2);
+        private readonly TimeSpan _messageCooldown = TimeSpan.FromSeconds(0); // Freak
 
         private readonly Queue<(NetUserId Channel, string Text, TimeSpan Timestamp)> _recentMessages = new();
         private const int MaxRecentMessages = 10;


### PR DESCRIPTION
Меня так корёжит с того, что я не могу засрать АХелп игроку(((

Ну, на самом деле просто из этого выходят проблемы в виде того, что если игрок/админ пишут сообщение, то КД распространяется на них обоих. ТО ЕСТЬ, если пишет админ каждые 2 секунды, то игрок не напишет сообщение, и наоборот так же. Энивей система анти-спама остаётся и спамить игруны не смогут, только педали. Изи.
И даже для педалей есть система, которая предупреждает что слишком часто отправляются сообщения.
<img width="888" height="777" alt="{FDAE3611-B3C8-4434-935E-A7BD91AAEFAB}" src="https://github.com/user-attachments/assets/99dc1f7b-aadf-43b1-8a72-26dab40d023d" />

