### PR TITLE
[TWEAK] [BALANCE] 2 tc syndicate bombs xd

### DIFF
--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -198,7 +198,7 @@ namespace Content.Server.Administration.Systems
         private const ushort MessageLengthCap = 3000;
 
         // Mini-Ahelp-Antispam-Start
-        private readonly TimeSpan _messageCooldown = TimeSpan.FromSeconds(2);
+        private readonly TimeSpan _messageCooldown = TimeSpan.FromSeconds(0); // Freak
 
         private readonly Queue<(NetUserId Channel, string Text, TimeSpan Timestamp)> _recentMessages = new();
         private const int MaxRecentMessages = 10;

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -580,7 +580,7 @@
   description: uplink-exploding-syndicate-bomb-desc
   productEntity: SyndicateBomb
   cost:
-    Telecrystal: 2 # goob
+    Telecrystal: 12 # goob
   categories:
     - UplinkExplosives
   restockTime: 1800


### PR DESCRIPTION
Большие бомбы синдиката за 2 ТК слишком дёшево, вор с 30 ТК(из набора) может купить 15 бомб синдиката больших, только вдумайтесь, а две достаточно чтобы сравнять ядро ИИ с космосом. (по умолчанию у агентов 20 ТК, и они могут купить 10 бомб, что всё равно дохуища)

Я не знаю почему у меня прошлый коммит тоже накинулся, хз, ветка новая но видимо базируется на прошлой ветке я ебу