### PR TITLE
[TWEAK] [BALANCE] No more holy grenades in typan experimental technolohy, uahahaha.

### DIFF
--- a/Resources/Prototypes/_Mini/Recipes/Lathes/typan.yml
+++ b/Resources/Prototypes/_Mini/Recipes/Lathes/typan.yml
@@ -251,14 +251,14 @@
     Plastic: 100
     Gold: 50
 
-- type: latheRecipe
-  id: HolyHandGrenade
-  parent: TypanBaseExplosiveRecipe
-  result: HolyHandGrenade
-  materials:
-    Steel: 200
-    Gold: 300
-    Plasma: 100
+# - type: latheRecipe
+#   id: HolyHandGrenade
+#   parent: TypanBaseExplosiveRecipe
+#   result: HolyHandGrenade
+#   materials:
+#     Steel: 200
+#     Gold: 300
+#     Plasma: 100
 
 - type: latheRecipe
   id: WhiteholeGrenade

--- a/Resources/Prototypes/_Mini/Research/weaponry.yml
+++ b/Resources/Prototypes/_Mini/Research/weaponry.yml
@@ -384,13 +384,13 @@
   id: TypanExperimentalGrenades
   name: research-technology-experimental-grenades
   icon:
-    sprite: Objects/Weapons/Grenades/holyhandgrenade.rsi
+    sprite: Objects/Weapons/Grenades/whiteholegrenade.rsi
     state: icon
   discipline: TypanWeaponry
   tier: 3
-  cost: 30000
+  cost: 10000
   recipeUnlocks:
-  - HolyHandGrenade
+  # - HolyHandGrenade
   - WhiteholeGrenade
   # Goobstation R&D Console rework start
   position: 0,-8


### PR DESCRIPTION
1. Крафт был слишком дешевый
2. Святые гранаты тайпану не нужны вообще, их используют другие антаги чтобы разъебывать станцию

Так же снизил цену исследования, т.к там меньше теперь нет святой гранаты. Думаю это справедливо

<img width="383" height="188" alt="{61118D87-0525-4012-B84C-8890968805A4}" src="https://github.com/user-attachments/assets/cc9c1458-3ff8-44c5-a94e-3757ec6aa31d" />

<img width="629" height="72" alt="{EFB384CD-73DA-4060-BE46-62EEF3972743}" src="https://github.com/user-attachments/assets/784163a8-efeb-43c5-a1b2-f8aee2ed9425" />
