### PR TITLE
[HOTFIX] пассажиры больше не кадеты ОСЩ, клянусь

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -767,7 +767,7 @@ namespace Content.Shared.Preferences
                     toRemove.Add(roleName);
                     continue;
                 }
-
+                loadouts.Role = roleName;
                 loadouts.EnsureValid(this, session, collection);
             }
 

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -764,6 +764,7 @@ namespace Content.Shared.Preferences
             {
                 if (!prototypeManager.HasIndex<RoleLoadoutPrototype>(roleName))
                 {
+
                     toRemove.Add(roleName);
                     continue;
                 }

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -764,10 +764,10 @@ namespace Content.Shared.Preferences
             {
                 if (!prototypeManager.HasIndex<RoleLoadoutPrototype>(roleName))
                 {
-
                     toRemove.Add(roleName);
                     continue;
                 }
+
                 loadouts.Role = roleName;
                 loadouts.EnsureValid(this, session, collection);
             }


### PR DESCRIPTION
В общем, через лодауты можно брать лодауты других профессий. Это позволяет брать такое вот снаряжение раундстартом на пассажире(гипоспрей, омнизин, 70 армора раундстартом, боевые перчатки)

<img width="561" height="315" alt="{76428D7D-B058-4B61-91E8-EB9ABDC383FB}" src="https://github.com/user-attachments/assets/c32fd9dc-75bf-4551-bfda-427ea15816f5" />

Как это делается я рассказывать не буду, из кода в общем-то и так понятно

оригинальный ПР
https://github.com/Goob-Station/Goob-Station/pull/5660
