### PR TITLE
[TWEAK] Теперь роадмап не вызывается после лобби стейта автоматически

### DIFF
--- a/Content.Client/ADT/Roadmap/RoadmapUIController.cs
+++ b/Content.Client/ADT/Roadmap/RoadmapUIController.cs
@@ -12,8 +12,6 @@ public sealed class RoadmapUIController : UIController, IOnStateEntered<LobbySta
     {
         if (_shown || _window != null)
             return;
-
-        ToggleRoadmap();
     }
 
     public void ToggleRoadmap()


### PR DESCRIPTION
убрал функцию вызова роадмапа автоматически после OnStateEntered(LobbyState state), потому что она меня бесит и там ничего не меняется, нафиг этот роадмап дурацкий блин дуралеи 

Всё ещё можно его включить нажав соответствующую кнопку 

<img width="162" height="61" alt="{6642E1BC-9309-416B-BA7F-D5902FF54B0C}" src="https://github.com/user-attachments/assets/0fbc96c4-f362-4643-a9de-27d5f03fdb9f" />
