### PR TITLE
[FIX] Fix logo sizing in main menu for better aspect ratio

### DIFF
--- a/Content.Client/MainMenu/UI/MainMenuControl.xaml
+++ b/Content.Client/MainMenu/UI/MainMenuControl.xaml
@@ -27,7 +27,8 @@ SPDX-License-Identifier: MIT
                   StyleIdentifier="mainMenuVBox"
                   SeparationOverride="3">
         <TextureRect Name="Logo"
-                     Stretch="KeepCentered"/>
+                     SetSize="420 232"
+                     Stretch="KeepAspectCentered"/>
         <GridContainer Columns="2">
             <Label Text="{Loc 'main-menu-username-label'}" />
             <LineEdit Name="UsernameBox"


### PR DESCRIPTION
# Мб это выглядит не очень, но мне похуй лол. Функционально прошлый вариант реально плох

## Было:
<img width="1920" height="1044" alt="изображение" src="https://github.com/user-attachments/assets/b8e987cb-3e4e-4256-803a-e93555aefd9c" />
(если не развертывать фулл резолюшн, то нельзя нажать кнопку присоединится

## Стало:
<img width="1544" height="808" alt="{DB47168C-1B97-48CC-8566-3D395B1DDCF9}" src="https://github.com/user-attachments/assets/3748b238-e663-4a6b-9736-5ab3db019c38" />
(теперь можно нажать кнопку даже не с фулл резолюшеном)

