### PR TITLE
[REFACTOR] stun method calls to use TryUpdateStunDuration

### DIFF
--- a/Content.Server/_FreakyStation/Psionics/PsionicSystem.cs
+++ b/Content.Server/_FreakyStation/Psionics/PsionicSystem.cs
@@ -307,7 +307,7 @@ public sealed class PsionicSystem : EntitySystem
                 continue;
 
             drainedTargets++;
-            _stun.TryStun(target, component.BioSurgeStunDuration, true);
+            _stun.TryUpdateStunDuration(target, component.BioSurgeStunDuration);
 
             if (drainedTargets >= component.BioSurgeMaxTargets)
                 break;
@@ -385,7 +385,7 @@ public sealed class PsionicSystem : EntitySystem
             if (target == uid)
                 continue;
 
-            _stun.TryStun(target, TimeSpan.FromSeconds(0.9f), true);
+            _stun.TryUpdateStunDuration(target, TimeSpan.FromSeconds(0.9f));
             _damageable.TryChangeDamage(target, damage, origin: uid);
         }
 
@@ -494,7 +494,7 @@ public sealed class PsionicSystem : EntitySystem
 
     private void TriggerNeuroshock(EntityUid uid, PsionicComponent component)
     {
-        _stun.TryStun(uid, component.NeuroshockStunDuration, true);
+        _stun.TryUpdateStunDuration(uid, component.NeuroshockStunDuration);
 
         var damageType = _prototype.Index(component.NeuroshockDamageType);
         var damage = new DamageSpecifier(damageType, component.NeuroshockDamage);


### PR DESCRIPTION
каша делал псионику до апстрима, а после апстрима поменялись методы стана, из-за чего сборка не компилилась. Саму псионику я не доделывал и не исправлял, просто пофиксил ошибки компила

Update stun method calls to utilize `TryUpdateStunDuration`, improving code clarity and consistency in handling stun durations. This change enhances maintainability without altering existing functionality.

